### PR TITLE
Simplify grammar

### DIFF
--- a/fhirpath.g4
+++ b/fhirpath.g4
@@ -5,7 +5,7 @@ grammar fhirpath;
 //version without precedence and left-recursion
 //expression: term (righthand)*;
 //righthand: op term | '.' function;
-//term: '(' expression ')' | const | predicate;
+//term: '(' expression ')' | fpconst | predicate;
 //op: LOGIC | COMP | '*' | '/' | '+' | '-' | '|' | '&';
 
 prog: line (line)*;
@@ -14,21 +14,17 @@ line: ID ( '(' predicate ')') ':' expr '\r'? '\n';
 
 //prog: expression (';' expression)* ';'?;
 
-expr:
-        expr ('*' | '/') expr |
-        expr ('+' | '-') expr |
-        expr ('|' | '&') expr |
-        expr COMP expr |
-        expr LOGIC expr |
-        '(' expr ')' |
-        predicate |
-        const;
+expr_no_binop: '(' expr ')' | predicate | fpconst;
+expr: binop | expr_no_binop;
 
-predicate : item ('.' item)* ;
+binop_operator: ( LOGIC | COMP | BOOL ) ;
+binop: expr_no_binop binop_operator expr_no_binop ;
+
+predicate : ('$context' | '$resource' | '$parent' | item) ('.' item)* ;
 item: element recurse? | function | axis_spec | '(' expr ')';
 element: ID CHOICE?;
 recurse: '*';
-axis_spec: '*' | '**' | '$context' | '$resource' | '$parent' ;
+axis_spec: '*' | '**' ;
 
 function: ID '(' param_list? ')';
 param_list: expr (',' expr)*;
@@ -37,7 +33,7 @@ param_list: expr (',' expr)*;
 //    expr |
 //    expr '..' expr;
 
-const: STRING |
+fpconst: STRING |
        '-'? NUMBER |
        BOOL |
        CONST;

--- a/fhirpath.md
+++ b/fhirpath.md
@@ -51,11 +51,11 @@ Note: $resource and $parent are only allowed in invariants
  
 There is a special case around the entry point, where the type of the entry point can be represented, but is optional. To illustrate this point, take the path 
 
-	telecom.where(use = 'phone').value
+	telecom.where(use = 'work').value
 
 This can be evaluated as an expression on a Patient resource, or other kind of resources. However, for natural human use, expressions are often prefixed with the name of the context in which they are used:
 
-	Patient.telecom.where(use = 'phone').value
+	Patient.telecom.where(use = 'work').value
   
 These 2 expressions have the same outcome, but when evaluating the second, the evaluation will only produce results when used on a Patient resource.
 
@@ -190,6 +190,7 @@ True if the left collection is equal to the right collection
 
 * equality is determined by comparing all the properties of the children
 * todo: does order matter in sub-collections? 
+* todo: does precision matter?
 * typically, this operator is used with a single fixed values. This means that Patient.telecom.system = 'phone' will return an empty collection if there is more than one telecom with a use typically, you'd want Patient.telecom.where(system = 'phone')</td></tr>
 </table>
 


### PR DESCRIPTION
Reduce a bit of duplication, and rename the identifier `const` which Antlr complains about on Java because `const` is a reserved word (const is only an identifier in the grammar, not in the actual syntax so this shouldn't be much of a change)